### PR TITLE
Adding support for calling AmazonSQSClient. without id/password to support authentication via IAM role.

### DIFF
--- a/src/main/clojure/cemerick/bandalore.clj
+++ b/src/main/clojure/cemerick/bandalore.clj
@@ -19,6 +19,11 @@
 (defn create-client
   "Creates a synchronous AmazonSQSClient using the provided account id, secret key,
    and optional com.amazonaws.ClientConfiguration."
+  ([]
+    (create-client (com.amazonaws.ClientConfiguration.)))
+  ([client-config]
+    (AmazonSQSClient.
+      (.withUserAgent client-config "Bandalore - SQS for Clojure")))
   ([id secret-key]
     (create-client id secret-key (com.amazonaws.ClientConfiguration.)))
   ([id secret-key client-config]


### PR DESCRIPTION
From EC2 instance with IAM Role, we can now create client like this (create-client).
