### PR TITLE
Add long polling support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <dependency>
             <groupId>com.amazonaws</groupId>
             <artifactId>aws-java-sdk</artifactId>
-            <version>1.3.21.1</version>
+            <version>1.8.0</version>
         </dependency>
     </dependencies>
 

--- a/src/main/clojure/cemerick/bandalore.clj
+++ b/src/main/clojure/cemerick/bandalore.clj
@@ -128,10 +128,10 @@
                                         :or {limit 1
                                              attributes #{}}}]
   (let [req (-> (ReceiveMessageRequest. queue-url)
-              (.withMaxNumberOfMessages (-> limit (min 10) (max 1) int Integer.))
+              (.withMaxNumberOfMessages (-> limit (min 10) (max 1) int Integer/valueOf))
               (.withAttributeNames attributes))
-        req (if wait-time-seconds (.withWaitTimeSeconds req (Integer. (int wait-time-seconds))) req)
-        req (if visibility (.withVisibilityTimeout req (Integer. (int visibility))) req)]
+        req (if wait-time-seconds (.withWaitTimeSeconds req (Integer/valueOf (int wait-time-seconds))) req)
+        req (if visibility (.withVisibilityTimeout req (Integer/valueOf (int visibility))) req)]
     (->> (.receiveMessage client req)
       .getMessages
       (map (partial message-map queue-url)))))

--- a/src/test/clojure/cemerick/bandalore_test.clj
+++ b/src/test/clojure/cemerick/bandalore_test.clj
@@ -121,3 +121,11 @@
   (let [v (-> (receive client *test-queue-url* :visibility 5) first :body read-string)]
     (is (some #(= v (-> % :body read-string)) (polling-receive client *test-queue-url* :max-wait 10000)))))
 
+(defsqstest test-receive-long-polling
+  (let [q *test-queue-url*
+        no-poll (future (receive client q))
+        long-poll (future (receive client q :wait-time-seconds 20))]
+    (Thread/sleep 10000)
+    (send client q "1")
+    (is (== 0 (count @no-poll)) "Should not return messages")
+    (is (== 1 (count @long-poll)) "Should return 1 message")))


### PR DESCRIPTION
Adds long polling support to receive message requests.

A short description from the [SDK javadoc](http://docs.aws.amazon.com/AWSJavaSDK/latest/javadoc/com/amazonaws/services/sqs/model/ReceiveMessageRequest.html#withWaitTimeSeconds%28java.lang.Integer%29) describing advantages of long polling.

> Long poll support is enabled by using the WaitTimeSeconds parameter. For more information, see Amazon SQS Long Poll in the [Amazon SQS Developer Guide](http://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-long-polling.html) .
> Short poll is the default behavior where a weighted random set of machines is sampled on a ReceiveMessage call. This means only the messages on the sampled machines are returned. If the number of messages in the queue is small (less than 1000), it is likely you will get fewer messages than you requested per ReceiveMessage call. If the number of messages in the queue is extremely small, you might not receive any messages in a particular ReceiveMessage response; in which case you should repeat the request.
